### PR TITLE
Fixed typo in msca-installer.ts

### DIFF
--- a/src/msca-toolkit/msca-installer.ts
+++ b/src/msca-toolkit/msca-installer.ts
@@ -7,7 +7,7 @@ import * as exec from '@actions/exec';
 export class MscaInstaller {
 
     async install(cliVersion: string) {
-        console.log('Installing Microsot Security Code Analysis Cli...');
+        console.log('Installing Microsoft Security Code Analysis Cli...');
 
         if (process.env.MSCA_FILEPATH) {
             console.log(`MSCA Cli File Path overriden by %MSCA_FILEPATH%: ${process.env.MSCA_FILEPATH}`);


### PR DESCRIPTION
A single 'f' was added to a `console.log();` statement.

Not sure why a '}' was removed and then added in the last line (269), I didn't touch that, maybe some sort of scope checker?