### PR TITLE
Use Actions terminology when talking about Actions runners

### DIFF
--- a/.github/workflows/sample-workflow-ubuntu-latest.yml
+++ b/.github/workflows/sample-workflow-ubuntu-latest.yml
@@ -23,8 +23,8 @@ jobs:
     # Ensure a compatible version of dotnet is installed.
     # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.
     # A version greater than or equal to v3.1.201 of dotnet must be installed on the agent in order to run this action.
-    # Remote agents already have a compatible version of dotnet installed and this step may be skipped.
-    # For local agents, ensure dotnet version 3.1.201 or later is installed by including this action:
+    # GitHub hosted runners already have a compatible version of dotnet installed and this step may be skipped.
+    # For self-hosted runners, ensure dotnet version 3.1.201 or later is installed by including this action:
     # - uses: actions/setup-dotnet@v1
     #   with:
     #     dotnet-version: '3.1.x'

--- a/.github/workflows/sample-workflow-windows-latest.yml
+++ b/.github/workflows/sample-workflow-windows-latest.yml
@@ -23,8 +23,8 @@ jobs:
     # Ensure a compatible version of dotnet is installed.
     # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.
     # A version greater than or equal to v3.1.201 of dotnet must be installed on the agent in order to run this action.
-    # Remote agents already have a compatible version of dotnet installed and this step may be skipped.
-    # For local agents, ensure dotnet version 3.1.201 or later is installed by including this action:
+    # GitHub hosted runners already have a compatible version of dotnet installed and this step may be skipped.
+    # For self-hosted runners, ensure dotnet version 3.1.201 or later is installed by including this action:
     # - uses: actions/setup-dotnet@v1
     #   with:
     #     dotnet-version: '3.1.x'

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ steps:
     sarif_file: ${{ steps.ossar.outputs.sarifFile }}
 ```
 
-**Note:** The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201. A version greater than or equal to v3.1.201 of dotnet must be installed on the agent in order to run this action. Remote agents already have a compatible version of dotnet installed. To ensure a compatible version of dotnet is installed on your desktop agent, please configure the [actions/setup-dotnet](https://github.com/actions/setup-dotnet) action.
+**Note:** The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201. A version greater than or equal to v3.1.201 of dotnet must be installed on the runner in order to run this action. GitHub hosted runners already have a compatible version of dotnet installed. To ensure a compatible version of dotnet is installed on a self-hosted runner, please configure the [actions/setup-dotnet](https://github.com/actions/setup-dotnet) action.
 
 ```
 - uses: actions/setup-dotnet@v1


### PR DESCRIPTION
In the context of GitHub Actions, where the workflows will run, users may not be familiar with the terms "local agent" and "remote agent". This commit replaces those terms with the relevant Actions terms.