### PR TITLE
Replace link of mscadocs with msca-nuget

### DIFF
--- a/.github/workflows/on-push-verification.yml
+++ b/.github/workflows/on-push-verification.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     # Ensure a compatible version of dotnet is installed.
-    # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.
+    # The [Microsoft Security Code Analysis CLI](https://aka.ms/msca-nuget) is built with dotnet v3.1.201.
     # A version greater than or equal to v3.1.201 of dotnet must be installed on the agent in order to run this action.
     # Remote agents already have a compatible version of dotnet installed and this step may be skipped.
     # For local agents, ensure dotnet version 3.1.201 or later is installed by including this action:

--- a/.github/workflows/sample-workflow-ubuntu-latest.yml
+++ b/.github/workflows/sample-workflow-ubuntu-latest.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
 
     # Ensure a compatible version of dotnet is installed.
-    # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.
+    # The [Microsoft Security Code Analysis CLI](https://aka.ms/msca-nuget) is built with dotnet v3.1.201.
     # A version greater than or equal to v3.1.201 of dotnet must be installed on the agent in order to run this action.
     # GitHub hosted runners already have a compatible version of dotnet installed and this step may be skipped.
     # For self-hosted runners, ensure dotnet version 3.1.201 or later is installed by including this action:

--- a/.github/workflows/sample-workflow-windows-latest.yml
+++ b/.github/workflows/sample-workflow-windows-latest.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
 
     # Ensure a compatible version of dotnet is installed.
-    # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.
+    # The [Microsoft Security Code Analysis CLI](https://aka.ms/msca-nuget) is built with dotnet v3.1.201.
     # A version greater than or equal to v3.1.201 of dotnet must be installed on the agent in order to run this action.
     # GitHub hosted runners already have a compatible version of dotnet installed and this step may be skipped.
     # For self-hosted runners, ensure dotnet version 3.1.201 or later is installed by including this action:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The OSSAR action is currently in beta and runs on the `windows-latest` queue, as
 
 # Overview
 
-This action runs the [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) for security analysis by:
+This action runs the [Microsoft Security Code Analysis CLI](https://aka.ms/msca-nuget) for security analysis by:
 
 * Installing the Microsoft Security Code Analysis CLI
 * Installing the latest policy or referencing the local `policy/github.gdnpolicy` file
@@ -53,7 +53,7 @@ steps:
     sarif_file: ${{ steps.ossar.outputs.sarifFile }}
 ```
 
-**Note:** The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201. A version greater than or equal to v3.1.201 of dotnet must be installed on the runner in order to run this action. GitHub hosted runners already have a compatible version of dotnet installed. To ensure a compatible version of dotnet is installed on a self-hosted runner, please configure the [actions/setup-dotnet](https://github.com/actions/setup-dotnet) action.
+**Note:** The [Microsoft Security Code Analysis CLI](https://aka.ms/msca-nuget) is built with dotnet v3.1.201. A version greater than or equal to v3.1.201 of dotnet must be installed on the runner in order to run this action. GitHub hosted runners already have a compatible version of dotnet installed. To ensure a compatible version of dotnet is installed on a self-hosted runner, please configure the [actions/setup-dotnet](https://github.com/actions/setup-dotnet) action.
 
 ```
 - uses: actions/setup-dotnet@v1

--- a/policy/github.nuspec
+++ b/policy/github.nuspec
@@ -5,7 +5,7 @@
     <version>1.1.0</version>
     <description>Microsoft Security Code Analysis Policy for GitHub.</description>
     <authors>Microsoft</authors>
-    <projectUrl>https://aka.ms/mscadocs</projectUrl>
+    <projectUrl>https://aka.ms/msca-nuget</projectUrl>
     <language>en-US</language>
     <license type="expression">MS-PL</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
The MSCA offering is being deprecated, but the CLI engine is not. Change the link from their documentation to msca-nuget.