### PR TITLE
Issue #44 Update node version from 16 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ outputs:
   sarifFile:
     description: A file path to a SARIF results file.
 runs:
-  using: 'node18'
+  using: 'node20'
   main: 'lib/action.js'

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ outputs:
   sarifFile:
     description: A file path to a SARIF results file.
 runs:
-  using: 'node16'
+  using: 'node18'
   main: 'lib/action.js'


### PR DESCRIPTION
This PR updates node version from 16 to 20. 

With this PR, OSSAR checking that requires `eslint` should work, since they require at least node version 18: https://eslint.org/docs/latest/use/getting-started

close #44 